### PR TITLE
Organ damage likelihood tweak

### DIFF
--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -68,7 +68,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 		if(laser || BP_IS_ROBOTIC(src))
 			damage_amt += burn
 			cur_damage += burn_dam
-		var/organ_damage_threshold = 10
+		var/organ_damage_threshold = 5
 		if(sharp)
 			organ_damage_threshold *= 0.5
 		var/organ_damage_prob = 5 * damage_amt/organ_damage_threshold //more damage, higher chance to damage


### PR DESCRIPTION
Halved threshold above which brute damage has a chance to injure organs. Increases chance for injury but still keeps it quite low (1/20 with sharp weapon, then another ~25% chance of failing to pick an organ based on relative_size) at the threshold (5 damage.)
Intention is to allow smaller projectiles and sharp weapons a greater chance of dealing lasting damage.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->